### PR TITLE
Fix ansible filter (from .utils to .netcommon)

### DIFF
--- a/ansible/templates/cisco-ios.j2
+++ b/ansible/templates/cisco-ios.j2
@@ -53,7 +53,7 @@ interface {{ intf.name }}
   {% endif %}
     {% for ip in ip_addresses.json.results %}
       {% if ip.assigned_object.name == intf.name %}
-  ip address {{ ip.address.split('/')[0] }} {{ ip.address | ansible.utils.ipaddr('netmask') }}  
+  ip address {{ ip.address.split('/')[0] }} {{ ip.address | ansible.netcommon.ipaddr('netmask') }}  
       {% endif %}
     {% endfor %}
   no shutdown

--- a/ansible/templates/cisco-ios.j2
+++ b/ansible/templates/cisco-ios.j2
@@ -53,7 +53,7 @@ interface {{ intf.name }}
   {% endif %}
     {% for ip in ip_addresses.json.results %}
       {% if ip.assigned_object.name == intf.name %}
-  ip address {{ ip.address.split('/')[0] }} {{ ip.address | ansible.netcommon.ipaddr('netmask') }}  
+  ip address {{ ip.address.split('/')[0] }} {{ ip.address | ansible.utils.ipaddr('netmask') | first }}  
       {% endif %}
     {% endfor %}
   no shutdown


### PR DESCRIPTION
The current ansible filter being used, is from an old ansible version and generates the mask as a list, creating an error on the template:

with:
`  ip address {{ ip.address.split('/')[0] }} {{ ip.address | ansible.utils.ipaddr('netmask') }}  `
Template generates:
`  ip address 192.168.0.1 ['255.255.255.0']  `

Newer/current ansible versions should use the netcommon module, which properly generates a text-formatted mask for the template:

with:
`  ip address {{ ip.address.split('/')[0] }} {{ ip.address | ansible.netcommon.ipaddr('netmask') }} `
Template Generates:
`  ip address 192.168.0.1 255.255.255.0  `