### PR TITLE
Use markdown links with image thumbnail instead of iframe

### DIFF
--- a/modules/1-Introduction/1-introduction.md
+++ b/modules/1-Introduction/1-introduction.md
@@ -68,13 +68,13 @@ NetBox tracks and manages a wide variety of IPAM components, including:
 ## Video  1 - Introduction to the NetBox Web Interface
 The best way to understand the power of NetBox is to dive right in and start exploring, and this short video will give you a guided tour of the Web Interface: 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/zT82jOUCcW4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Guided tour of the web interface](https://img.youtube.com/vi/zT82jOUCcW4/0.jpg)](https://www.youtube.com/watch?v=zT82jOUCcW4)
 
 ## Video 2 - Introduction to the NetBox REST API
 For a deep dive, you can check out the NetBox [REST API documentation](https://docs.netbox.dev/en/stable/integrations/rest-api/). 
 For now, let's take a quick tour of the REST API in this short video, which will help you to get up and running in no time: 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Gsarb0elmoA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Quick tour of the REST API](https://img.youtube.com/vi/Gsarb0elmoA/0.jpg)](https://www.youtube.com/watch?v=Gsarb0elmoA)
 
 ## Summary
 In this module you have learned what NetBox is along with it's main features and benefits. You also learned how to navigate around the Web Interface and explored the REST API, and how to use it to programmatically interact with NetBox.

--- a/modules/10-providers-and-circuits/10-providers-and-circuits.md
+++ b/modules/10-providers-and-circuits/10-providers-and-circuits.md
@@ -52,7 +52,7 @@ OK, so that's the planning work done - let's get to the fun stuff!! This video w
 
 If you are following along, don't forget to use the [Postman Collection](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/postman) for making the API calls. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/GgnBzAYgZGY" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Adding the provider and the internet circuit](https://img.youtube.com/vi/GgnBzAYgZGY/0.jpg)](https://www.youtube.com/watch?v=GgnBzAYgZGY)
 
 ## Summary
 In this module you have learned how NetBox models providers and circuits, and how to "connect" circuits directly to device interfaces via cables. You also added to your Postman collection for NetBox, to make API calls to add this data programmatically. 

--- a/modules/11-custom-scripts/11-custom-scripts.md
+++ b/modules/11-custom-scripts/11-custom-scripts.md
@@ -82,7 +82,7 @@ OK, so that's the overview of the scripts that will be used - let's see them in 
 
 If you are following along, don't forget to use the [Custom Script Examples](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/custom_scripts) 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/mBZ8HGVuZyE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Netbox custom scripts](https://img.youtube.com/vi/mBZ8HGVuZyE/0.jpg)](https://www.youtube.com/watch?v=mBZ8HGVuZyE)
 
 ## Summary
 In this module you have learned what Custom Scripts are in NetBox and what kind of tasks they can be used to accomplish. You also learned the basics of writing Custom Scripts and where to find documentation to help you develop your own scripts. You also got a head start on writing your own Custom Scripts collection, with two example scripts to get you up and running. 

--- a/modules/12-the-boss-is-asking-for-a-report/12-the-boss-is-asking-for-a-report.md
+++ b/modules/12-the-boss-is-asking-for-a-report/12-the-boss-is-asking-for-a-report.md
@@ -77,7 +77,8 @@ OK, so that's the overview of NetBox reports - let's see them in action!! This v
 
 If you are following along, don't forget to use the [Report Examples](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/reports).
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/RH3Syxm3EKA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+[![Netbox reports](https://img.youtube.com/vi/RH3Syxm3EKA/0.jpg)](https://www.youtube.com/watch?v=RH3Syxm3EKA)
 
 ## Summary
 In this module you have learned what NetBox reports are and what kind of things they can be used to verify. You also learned the basics of reports and where to find documentation and examples to help you develop your own reports. You also kick started your own reports collection, with two example reports to get you up and running. 

--- a/modules/2-setting-up-the-organization/2-setting-up-the-organization.md
+++ b/modules/2-setting-up-the-organization/2-setting-up-the-organization.md
@@ -53,7 +53,7 @@ If you are following along you can find the [CSV data](https://github.com/netbox
 
 With that said, let's get started! 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Lit6H8XF2d0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Setting up the organization](https://img.youtube.com/vi/Lit6H8XF2d0/0.jpg)](https://www.youtube.com/watch?v=Lit6H8XF2d0)
 
 ## Summary
 In this module you learned how to set up your organization's data in NetBox using the Web Interface. 

--- a/modules/3-adding-the-kit/3-adding-the-kit.md
+++ b/modules/3-adding-the-kit/3-adding-the-kit.md
@@ -63,7 +63,8 @@ The video demo will now show you how to add all of the device data into NetBox m
 
 If you are following along, don't forget to use the [Postman Collection](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/postman) for making the API calls and the [YAML files](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/modules/3-adding-the-kit/yaml_data) used for adding device types.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/dA3LZiV7UIg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+[![Adding devices into Netbox](https://img.youtube.com/vi/dA3LZiV7UIg/0.jpg)](https://www.youtube.com/watch?v=dA3LZiV7UIg)
 
 ## Summary
 In this module you learned how to add devices into NetBox, making use of the NetBox REST API and a Postman collection. 

--- a/modules/4-ip-addressing-and-vlans/4-ip-addressing-and-vlans.md
+++ b/modules/4-ip-addressing-and-vlans/4-ip-addressing-and-vlans.md
@@ -118,7 +118,7 @@ All IP addresses assigned will be the next available, and allocated dynamically 
 ## Video - Adding IPAM Data Into NetBox
 OK, so that's the planning and design work done - now onto the demo! This video will step you through how to populate NetBox with the IPAM data using Ansible. As always the best way to understand the power of NetBox is to dive right in, so let's get started!
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/XCwO6RGpBpI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Adding IPAM data into Netbox](https://img.youtube.com/vi/XCwO6RGpBpI/0.jpg)](https://www.youtube.com/watch?v=XCwO6RGpBpI)
 
 ## Summary 
 In this module you have learned how NetBox Models IPAM data, how to integrate NetBox with Ansible, and in particular the collection of NetBox Ansible modules. If you have any questions on how to use Ansible with NetBox then there is a dedicated Slack channel **#ansible** on [netdev-community.slack.com](https://netdev-community.slack.com/) so don't hesitate to pop on over there and join in the discussion!

--- a/modules/5-making-the-connections/5-making-the-connections.md
+++ b/modules/5-making-the-connections/5-making-the-connections.md
@@ -58,7 +58,7 @@ OK, so that's the planning and design work done - now onto the demo! This video 
 
 If you are following along you can find the [CSV data](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/modules/5-making-the-connections/csv_data) in the course Git Repository. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/FTjqGPS2oSo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Adding cables and connections into Netbox](https://img.youtube.com/vi/FTjqGPS2oSo/0.jpg)](https://www.youtube.com/watch?v=FTjqGPS2oSo)
 
 ## Summary
 In this module you have learned how NetBox models Cables, Interface and Console connections, and how to bulk upload them via the web interface. 

--- a/modules/6-Setting-up-the-WiFi/6-Setting-up-the-WiFi.md
+++ b/modules/6-Setting-up-the-WiFi/6-Setting-up-the-WiFi.md
@@ -44,7 +44,7 @@ OK, so that's the planning and design work done - now onto the demo! This video 
 
 If you are following along you can find the [python scripts](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/python_scripts) in the course Git Repository and you can use these as a starting point for building your collection of Python scripts for NetBox. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/rewxPa58VCw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Adding wireless LANs into Netbox](https://img.youtube.com/vi/rewxPa58VCw/0.jpg)](https://www.youtube.com/watch?v=rewxPa58VCw)
 
 ## Summary
 In this module you have learned how NetBox Models Wireless LANs, and how to add Wireless LAN data using simple Python scripts.

--- a/modules/7-automate-all-the-things/7-automate-all-the-things.md
+++ b/modules/7-automate-all-the-things/7-automate-all-the-things.md
@@ -186,7 +186,7 @@ OK, so with all that said - let's get to the fun stuff!! This video will step yo
 
 If you are following along you can find the [Ansible playbooks](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/ansible) in the course Git Repository and you can use these as a starting point for building your collection of playbooks for NetBox. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/aHx9EpCvi2U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Automating device configurations with Netbox and Ansible](https://img.youtube.com/vi/aHx9EpCvi2U/0.jpg)](https://www.youtube.com/watch?v=aHx9EpCvi2U)
 
 ## Summary
 In this module you have learned how to set up Ansible to use NetBox as the source of truth for it's Dynamic Inventory, and how to use Ansible to extract device data from NetBox and use this to automate the generation of device configuration files using Jinja templates. 

--- a/modules/8-what-about-virtualization/8-what-about-virtualization.md
+++ b/modules/8-what-about-virtualization/8-what-about-virtualization.md
@@ -95,7 +95,7 @@ OK, so that's the planning work done - let's get to the fun stuff!! This video w
 
 If you are following along you can find the [CSV data](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/modules/8-what-about-virtualization/csv_data) for the new devices and cables in the course Git Repository. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/D5iDdjZMUeo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Adding virtualization clusters and virtual machines](https://img.youtube.com/vi/D5iDdjZMUeo/0.jpg)](https://www.youtube.com/watch?v=D5iDdjZMUeo)
 
 ## Summary
 In this module you have learned how NetBox models Virtualization, including Cluster Types, Clusters, Platforms, VM's and VM Interfaces. You also learned how to model network services and associate them with devices or VM's, and specific IP addresses. 

--- a/modules/9-powering-up/9-powering-up.md
+++ b/modules/9-powering-up/9-powering-up.md
@@ -115,7 +115,7 @@ OK, so that's the planning work done - let's make this happen in NetBox!! This v
 
 If you are following along you can find the [CSV data](https://github.com/netbox-community/netbox-zero-to-hero/tree/main/modules/9-powering-up/csv_data) for the PDU devices and the power cable connections in the course Git Repository. 
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Ky7UXDPTobA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[![Adding the facility power panels, feeds and PDUs](https://img.youtube.com/vi/Ky7UXDPTobA/0.jpg)](https://www.youtube.com/watch?v=Ky7UXDPTobA)
 
 ## Summary
 In this module you have learned how NetBox models facility power as discrete power panels and feeds. You also learned how to add Power Distribution Units (PDUs) to supply power to individual devices. 


### PR DESCRIPTION
The `iframe` HTML tag doesn't render properly in GH markdown. Updating the docs to use markdown links with thumbnail.